### PR TITLE
[Design]피드버튼크기통일,피드정렬수정,작성날짜위치수정,detailContents크기조정

### DIFF
--- a/src/pages/Channel/Channel.module.css
+++ b/src/pages/Channel/Channel.module.css
@@ -38,7 +38,7 @@
 }
 
 .detailContentArea.open {
-  flex: 1;
+  flex: 0.7;
 }
 
 .closeButton {
@@ -51,6 +51,3 @@
     height: 30px;
   }
 }
-
-
-

--- a/src/pages/Channel/components/ChannelFeed.module.css
+++ b/src/pages/Channel/components/ChannelFeed.module.css
@@ -25,8 +25,8 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    justify-content: center;
     gap: var(--spacing-12);
+    padding: var(--spacing-8) 0px;
 
     h3 {
       font-size: 1.2rem;
@@ -36,6 +36,7 @@
     iframe {
       max-width: 300px;
       aspect-ratio: 16/9;
+      padding: var(--spacing-12) 0px;
     }
 
     .audioPlayerAndImg {
@@ -80,6 +81,7 @@
       justify-content: center;
       align-items: center;
       gap: var(--spacing-4);
+      height: 32px;
     }
   }
 

--- a/src/pages/Channel/components/ChannelFeedAudio.tsx
+++ b/src/pages/Channel/components/ChannelFeedAudio.tsx
@@ -49,20 +49,10 @@ function ChannelFeedAudio({
         />
       </div>
       <div className={S.messageFeed}>
-        {title ? (
-          <>
-            <p>{author_nickname} </p>
-            <h3>
-              {title} <small>{createdTime}</small>
-            </h3>
-          </>
-        ) : (
-          <>
-            <p>
-              {author_nickname} <small>{createdTime}</small>
-            </p>
-          </>
-        )}
+        <p>
+          {author_nickname} <small>{createdTime}</small>
+        </p>
+        {title ? <h3>{title}</h3> : null}
         <div className={S.audioPlayerAndImg}>
           {audio_url ? (
             image_url ? (

--- a/src/pages/Channel/components/DetailContents.module.css
+++ b/src/pages/Channel/components/DetailContents.module.css
@@ -57,7 +57,7 @@
 }
 .replyContainer {
   flex: 1;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   .replies {
     display: flex;


### PR DESCRIPTION
## 작업 개요
채널피드 css를 수정하고 작성날짜위치를 수정했습니다. 

## 작업 내용
- [x] 피드 hover 시 나오는 버튼 크기 동일하게 수정
- [x] 피드 정렬 수정
- [x] 피드작성날짜 위치 통일(->작성자 옆) 
- [x] 댓글나오는부분 스크롤바 overflow 안 될 때는 보이지 않도록 수정
- [x] 댓글나오는부분 크기 줄임 

## 관련 이슈

## 테스트 결과 보고
