### PR TITLE
[Refactor] Feed Submit동작 시 렌더링 구조 변경

### DIFF
--- a/src/api/feeds.ts
+++ b/src/api/feeds.ts
@@ -265,7 +265,6 @@ export const addFeedsWithFiles = async ({
   image_file,
 }: InsertAllType) => {
   const { data: userData } = await supabase.auth.getUser();
-  if (!userData) alert("로그인 후에 글을 올릴 수 있습니다.");
 
   const pathArr = [];
   const now = Date.now();
@@ -287,14 +286,14 @@ export const addFeedsWithFiles = async ({
     audio_url = await uploadAndGetUrl(audio_path, audio_file, "feed-audio");
   }
 
-  const { error: dbError } = await supabase.from("feeds").insert({
+  const { data, error: dbError } = await supabase.from("feeds").insert({
     title,
     content,
     audio_url,
     image_url,
     channel_id,
     message_type,
-  });
+  }).select('*')
 
   // DB에 에러가 있으면 업로드 취소
   if (dbError) {
@@ -303,6 +302,8 @@ export const addFeedsWithFiles = async ({
     });
     throw dbError;
   }
+
+  return data?.[0] ?? null
 };
 
 /**

--- a/src/components/SubmitClipForm/index.tsx
+++ b/src/components/SubmitClipForm/index.tsx
@@ -12,12 +12,24 @@ interface Props {
   setRecordingData: React.Dispatch<
     React.SetStateAction<RecordingData | undefined>
   >;
+    handleAddSubmitFeed: (data: {
+    audio_url: string | null;
+    author_id: string;
+    channel_id: string;
+    content: string | null;
+    created_at: string;
+    id: string;
+    image_url: string | null;
+    message_type: "default" | "clip" | "image";
+    title: string | null;
+  }) => void;
 }
 
 function SubmitClipForm({
   recordingData,
   setRecordingData,
   curChannelId,
+  handleAddSubmitFeed,
 }: Props) {
   const [imagePreview, setImagePreview] = useState<string | undefined | null>("");
   const [feedImage, setFeedImage] = useState<File | undefined | null>();
@@ -37,11 +49,11 @@ function SubmitClipForm({
     if(file) setFilePreview(file, setImagePreview);
   }
 
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     console.log("전송");
 
-    addFeedsWithFiles({
+    const data = await addFeedsWithFiles({
       title,
       content,
       message_type: "clip",
@@ -49,6 +61,8 @@ function SubmitClipForm({
       image_file: feedImage,
       audio_file: recordingData?.file,
     });
+
+    handleAddSubmitFeed(data);
 
     handleDelete();
   }

--- a/src/pages/Channel/components/InputFeed.tsx
+++ b/src/pages/Channel/components/InputFeed.tsx
@@ -11,16 +11,25 @@ import { alert, showToast } from "@/components/common/CustomAlert";
 
 interface Props {
   curChannelId: string;
-  renderTailFeeds: () => Promise<void>;
-  scrollToBottom: () => void;
   isMember: boolean | null;
+  handleAddSubmitFeed: (data: {
+    audio_url: string | null;
+    author_id: string;
+    channel_id: string;
+    content: string | null;
+    created_at: string;
+    id: string;
+    image_url: string | null;
+    message_type: "default" | "clip" | "image";
+    title: string | null;
+  }) => void;
 }
 
 function InputFeed({
   curChannelId,
-  renderTailFeeds,
-  scrollToBottom,
+
   isMember,
+  handleAddSubmitFeed,
 }: Props) {
   // 데이터 상태관리
   const [recordingData, setRecordingData] = useState<RecordingData>();
@@ -57,10 +66,6 @@ function InputFeed({
     }
     setImage(undefined);
     setImagePreview(undefined);
-
-    requestAnimationFrame(() => {
-      scrollToBottom();
-    });
   };
 
   const handleClose = (e: MouseEvent) => {
@@ -90,14 +95,14 @@ function InputFeed({
         return;
       }
 
-      await addFeedsWithFiles({
+      const data = await addFeedsWithFiles({
         content: text.value,
         channel_id: curChannelId,
         message_type: "default",
         image_file: image,
       });
 
-      await renderTailFeeds();
+      handleAddSubmitFeed(data);
 
       initialize();
     }
@@ -153,6 +158,8 @@ function InputFeed({
         recordingData={recordingData}
         setRecordingData={setRecordingData}
         curChannelId={curChannelId}
+        handleAddSubmitFeed={handleAddSubmitFeed}
+        
       />
 
       {/* 이미지 프리뷰 영역 */}

--- a/src/pages/Channel/index.tsx
+++ b/src/pages/Channel/index.tsx
@@ -33,7 +33,6 @@ import { UserList } from "./components/UserList";
 import InputReplies from "./components/InputReplies";
 import { alert, confirmAlert } from "@/components/common/CustomAlert";
 import { convertNewFeedToFeedData } from "@/utils/convertFeedToFeedData";
-import { throttle } from "@/utils/Throttle";
 
 type FeedWithPreview = Tables<"get_feeds_with_user_and_likes"> & {
   preview_url?: string;

--- a/src/pages/Channel/index.tsx
+++ b/src/pages/Channel/index.tsx
@@ -456,24 +456,6 @@ function Channel() {
     scrollToBottom();
   }, [isSubmit, scrollToBottom]);
 
-  // useEffect(() => {
-  //   const container = feedContainerRef.current;
-  //   if (!container) return;
-  //   if (!isAtBottom) return
-
-  //   const handleScroll = throttle(() => {
-  //     const { scrollHeight, scrollTop, clientHeight } = container;
-  //     const isScrolledToBottom = scrollHeight - scrollTop - clientHeight < 100;
-  //     setIsAtBottom(isScrolledToBottom);
-  //   }, 200);
-
-  //   container.addEventListener("scroll", handleScroll);
-
-  //   return () => {
-  //     container.removeEventListener("scroll", handleScroll);
-  //   };
-  // }, [isAtBottom]);
-
   // 유저아바타프리뷰 url 가져오기
   const getPreviewImage = async (
     feed: Tables<"get_feeds_with_user_and_likes">

--- a/src/utils/convertFeedToFeedData.ts
+++ b/src/utils/convertFeedToFeedData.ts
@@ -1,0 +1,40 @@
+import type { Tables } from "@/@types/database.types";
+
+
+type NewFeedInput = {
+  id: string;
+  author_id: string;
+  channel_id: string;
+  content: string | null;
+  created_at: string;
+  image_url: string | null;
+  audio_url: string | null;
+  title: string | null;
+  message_type: "default" | "clip" | "image";
+};
+
+type FeedWithPreview = Tables<"get_feeds_with_user_and_likes"> & {
+  preview_url?: string;
+};
+
+export const convertNewFeedToFeedData = (
+  newFeed: NewFeedInput,
+  nickname: string | null,
+  profileUrl: string | null
+): FeedWithPreview => {
+  return {
+    audio_url: newFeed.audio_url,
+    author_id: newFeed.author_id,
+    author_nickname: nickname,
+    author_profile_url: profileUrl,
+    channel_id: newFeed.channel_id,
+    content: newFeed.content,
+    created_at: newFeed.created_at,
+    feed_id: newFeed.id,
+    image_url: newFeed.image_url,
+    like_count: 0,
+    message_type: newFeed.message_type,
+    title: newFeed.title,
+    preview_url: profileUrl ? profileUrl : undefined, // 있을 경우에만
+  };
+};


### PR DESCRIPTION
## 작업 개요
<!-- 어떤 작업을 했는지 간단히 작성해주세요 -->
기존 최하위 피드에서 그 다음 피드를 렌더링하는 방식에서 서버에 insert 하는 동작만 하고 사용자에게는 select 없이 렌더링된 내용이 보여지도록 낙관적 업데이트를 적용했습니다.

## 작업 내용
- [x] submit 렌더링 구조 변경
- [x] isAtBottom State로 하단을 보고 있는지 판별
- [x] 하단을 보고 있으면 최하단으로 따라 스크롤하도록 변경 

## 관련 이슈
Closes #120 

## 테스트 결과 보고
<!-- 테스트 결과나 내용 기입 -->
채널에 메세지 하나도 없을때 렌더링하지 못하는 버그 수정 - 이제 메세지 없는 빈 채널에도 잘 나옵니다.
위쪽을 보고 있어도 하단이 최신화되면 강제로 스크롤되던 현상을 수정했습니다. - UX 개선