### PR TITLE
[Feat] 피드, 댓글 삭제 기능 추가/안내문구 등 UX 개선

### DIFF
--- a/src/@types/database.types.ts
+++ b/src/@types/database.types.ts
@@ -4,869 +4,879 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json | undefined }
-  | Json[]
+  | Json[];
 
 export type Database = {
   // Allows to automatically instanciate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
-    PostgrestVersion: "12.2.3 (519615d)"
-  }
+    PostgrestVersion: "12.2.3 (519615d)";
+  };
   public: {
     Tables: {
       channels: {
         Row: {
-          created_at: string
-          description: string | null
-          genre_code: number | null
-          id: string
-          name: string
-          owner_id: string
-        }
+          created_at: string;
+          description: string | null;
+          genre_code: number | null;
+          id: string;
+          name: string;
+          owner_id: string;
+        };
         Insert: {
-          created_at?: string
-          description?: string | null
-          genre_code?: number | null
-          id?: string
-          name?: string
-          owner_id?: string
-        }
+          created_at?: string;
+          description?: string | null;
+          genre_code?: number | null;
+          id?: string;
+          name?: string;
+          owner_id?: string;
+        };
         Update: {
-          created_at?: string
-          description?: string | null
-          genre_code?: number | null
-          id?: string
-          name?: string
-          owner_id?: string
-        }
+          created_at?: string;
+          description?: string | null;
+          genre_code?: number | null;
+          id?: string;
+          name?: string;
+          owner_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "channels_genre_code_fkey"
-            columns: ["genre_code"]
-            isOneToOne: false
-            referencedRelation: "genres"
-            referencedColumns: ["code"]
+            foreignKeyName: "channels_genre_code_fkey";
+            columns: ["genre_code"];
+            isOneToOne: false;
+            referencedRelation: "genres";
+            referencedColumns: ["code"];
           },
           {
-            foreignKeyName: "channels_owner_id_fkey"
-            columns: ["owner_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "channels_owner_id_fkey";
+            columns: ["owner_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
-        ]
-      }
+        ];
+      };
       feed_replies: {
         Row: {
-          author_id: string | null
-          content: string
-          created_at: string
-          feed_id: string
-          id: string
-        }
+          author_id: string | null;
+          content: string;
+          created_at: string;
+          feed_id: string;
+          id: string;
+        };
         Insert: {
-          author_id?: string | null
-          content: string
-          created_at?: string
-          feed_id: string
-          id?: string
-        }
+          author_id?: string | null;
+          content: string;
+          created_at?: string;
+          feed_id: string;
+          id?: string;
+        };
         Update: {
-          author_id?: string | null
-          content?: string
-          created_at?: string
-          feed_id?: string
-          id?: string
-        }
+          author_id?: string | null;
+          content?: string;
+          created_at?: string;
+          feed_id?: string;
+          id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "feed_replies_author_id_fkey"
-            columns: ["author_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "feed_replies_author_id_fkey";
+            columns: ["author_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
           {
-            foreignKeyName: "feed_replies_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "feeds"
-            referencedColumns: ["id"]
+            foreignKeyName: "feed_replies_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "feeds";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "feed_replies_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["feed_id"]
+            foreignKeyName: "feed_replies_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["feed_id"];
           },
           {
-            foreignKeyName: "feed_replies_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_user_and_likes"
-            referencedColumns: ["feed_id"]
+            foreignKeyName: "feed_replies_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_user_and_likes";
+            referencedColumns: ["feed_id"];
           },
           {
-            foreignKeyName: "feed_replies_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "view_feed_search"
-            referencedColumns: ["id"]
+            foreignKeyName: "feed_replies_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "view_feed_search";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "feed_replies_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "view_feed_with_user"
-            referencedColumns: ["id"]
+            foreignKeyName: "feed_replies_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "view_feed_with_user";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       feeds: {
         Row: {
-          audio_url: string | null
-          author_id: string
-          channel_id: string
-          content: string | null
-          created_at: string
-          id: string
-          image_url: string | null
-          message_type: Database["public"]["Enums"]["message_type"]
-          title: string | null
-        }
+          audio_url: string | null;
+          author_id: string;
+          channel_id: string;
+          content: string | null;
+          created_at: string;
+          id: string;
+          image_url: string | null;
+          message_type: Database["public"]["Enums"]["message_type"];
+          title: string | null;
+        };
         Insert: {
-          audio_url?: string | null
-          author_id?: string
-          channel_id: string
-          content?: string | null
-          created_at?: string
-          id?: string
-          image_url?: string | null
-          message_type?: Database["public"]["Enums"]["message_type"]
-          title?: string | null
-        }
+          audio_url?: string | null;
+          author_id?: string;
+          channel_id: string;
+          content?: string | null;
+          created_at?: string;
+          id?: string;
+          image_url?: string | null;
+          message_type?: Database["public"]["Enums"]["message_type"];
+          title?: string | null;
+        };
         Update: {
-          audio_url?: string | null
-          author_id?: string
-          channel_id?: string
-          content?: string | null
-          created_at?: string
-          id?: string
-          image_url?: string | null
-          message_type?: Database["public"]["Enums"]["message_type"]
-          title?: string | null
-        }
+          audio_url?: string | null;
+          author_id?: string;
+          channel_id?: string;
+          content?: string | null;
+          created_at?: string;
+          id?: string;
+          image_url?: string | null;
+          message_type?: Database["public"]["Enums"]["message_type"];
+          title?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "feeds_author_id_fkey"
-            columns: ["author_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "feeds_author_id_fkey";
+            columns: ["author_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
           {
-            foreignKeyName: "feeds_channel_id_fkey"
-            columns: ["channel_id"]
-            isOneToOne: false
-            referencedRelation: "channels"
-            referencedColumns: ["id"]
+            foreignKeyName: "feeds_channel_id_fkey";
+            columns: ["channel_id"];
+            isOneToOne: false;
+            referencedRelation: "channels";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       genres: {
         Row: {
-          code: number
-          created_at: string
-          name: string
-        }
+          code: number;
+          created_at: string;
+          name: string;
+        };
         Insert: {
-          code?: number
-          created_at?: string
-          name: string
-        }
+          code?: number;
+          created_at?: string;
+          name: string;
+        };
         Update: {
-          code?: number
-          created_at?: string
-          name?: string
-        }
-        Relationships: []
-      }
+          code?: number;
+          created_at?: string;
+          name?: string;
+        };
+        Relationships: [];
+      };
       likes: {
         Row: {
-          created_at: string
-          feed_id: string
-          id: number
-          user_id: string
-        }
+          created_at: string;
+          feed_id: string;
+          id: number;
+          user_id: string;
+        };
         Insert: {
-          created_at?: string
-          feed_id: string
-          id?: number
-          user_id: string
-        }
+          created_at?: string;
+          feed_id: string;
+          id?: number;
+          user_id: string;
+        };
         Update: {
-          created_at?: string
-          feed_id?: string
-          id?: number
-          user_id?: string
-        }
+          created_at?: string;
+          feed_id?: string;
+          id?: number;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "likes_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "feeds"
-            referencedColumns: ["id"]
+            foreignKeyName: "likes_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "feeds";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "likes_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["feed_id"]
+            foreignKeyName: "likes_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["feed_id"];
           },
           {
-            foreignKeyName: "likes_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_user_and_likes"
-            referencedColumns: ["feed_id"]
+            foreignKeyName: "likes_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_user_and_likes";
+            referencedColumns: ["feed_id"];
           },
           {
-            foreignKeyName: "likes_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "view_feed_search"
-            referencedColumns: ["id"]
+            foreignKeyName: "likes_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "view_feed_search";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "likes_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "view_feed_with_user"
-            referencedColumns: ["id"]
+            foreignKeyName: "likes_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "view_feed_with_user";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "likes_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "likes_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
-        ]
-      }
+        ];
+      };
       notifications: {
         Row: {
-          created_at: string
-          feed_id: string | null
-          id: string
-          is_read: boolean
-          reply_id: string | null
-          sender_id: string
-          type: string
-          user_id: string
-        }
+          created_at: string;
+          feed_id: string | null;
+          id: string;
+          is_read: boolean;
+          reply_id: string | null;
+          sender_id: string;
+          type: string;
+          user_id: string;
+        };
         Insert: {
-          created_at?: string
-          feed_id?: string | null
-          id?: string
-          is_read?: boolean
-          reply_id?: string | null
-          sender_id: string
-          type: string
-          user_id: string
-        }
+          created_at?: string;
+          feed_id?: string | null;
+          id?: string;
+          is_read?: boolean;
+          reply_id?: string | null;
+          sender_id: string;
+          type: string;
+          user_id: string;
+        };
         Update: {
-          created_at?: string
-          feed_id?: string | null
-          id?: string
-          is_read?: boolean
-          reply_id?: string | null
-          sender_id?: string
-          type?: string
-          user_id?: string
-        }
+          created_at?: string;
+          feed_id?: string | null;
+          id?: string;
+          is_read?: boolean;
+          reply_id?: string | null;
+          sender_id?: string;
+          type?: string;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "notifications_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "feeds"
-            referencedColumns: ["id"]
+            foreignKeyName: "notifications_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "feeds";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "notifications_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["feed_id"]
+            foreignKeyName: "notifications_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["feed_id"];
           },
           {
-            foreignKeyName: "notifications_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_user_and_likes"
-            referencedColumns: ["feed_id"]
+            foreignKeyName: "notifications_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_user_and_likes";
+            referencedColumns: ["feed_id"];
           },
           {
-            foreignKeyName: "notifications_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "view_feed_search"
-            referencedColumns: ["id"]
+            foreignKeyName: "notifications_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "view_feed_search";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "notifications_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "view_feed_with_user"
-            referencedColumns: ["id"]
+            foreignKeyName: "notifications_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "view_feed_with_user";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "notifications_sender_id_fkey"
-            columns: ["sender_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "notifications_sender_id_fkey";
+            columns: ["sender_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
           {
-            foreignKeyName: "notifications_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "notifications_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
-        ]
-      }
+        ];
+      };
       playlists: {
         Row: {
-          created_at: string
-          genre_code: number | null
-          id: string
-          title: string
-          youtube_id: string
-        }
+          created_at: string;
+          genre_code: number | null;
+          id: string;
+          title: string;
+          youtube_id: string;
+        };
         Insert: {
-          created_at?: string
-          genre_code?: number | null
-          id?: string
-          title: string
-          youtube_id: string
-        }
+          created_at?: string;
+          genre_code?: number | null;
+          id?: string;
+          title: string;
+          youtube_id: string;
+        };
         Update: {
-          created_at?: string
-          genre_code?: number | null
-          id?: string
-          title?: string
-          youtube_id?: string
-        }
-        Relationships: []
-      }
+          created_at?: string;
+          genre_code?: number | null;
+          id?: string;
+          title?: string;
+          youtube_id?: string;
+        };
+        Relationships: [];
+      };
       user_channels: {
         Row: {
-          channel_id: string
-          created_at: string
-          user_id: string
-        }
+          channel_id: string;
+          created_at: string;
+          user_id: string;
+        };
         Insert: {
-          channel_id: string
-          created_at?: string
-          user_id?: string
-        }
+          channel_id: string;
+          created_at?: string;
+          user_id?: string;
+        };
         Update: {
-          channel_id?: string
-          created_at?: string
-          user_id?: string
-        }
+          channel_id?: string;
+          created_at?: string;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "user_channels_channel_id_fkey"
-            columns: ["channel_id"]
-            isOneToOne: false
-            referencedRelation: "channels"
-            referencedColumns: ["id"]
+            foreignKeyName: "user_channels_channel_id_fkey";
+            columns: ["channel_id"];
+            isOneToOne: false;
+            referencedRelation: "channels";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "user_channels_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "user_channels_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
-        ]
-      }
+        ];
+      };
       user_genres: {
         Row: {
-          genre_code: number
-          user_id: string
-        }
+          genre_code: number;
+          user_id: string;
+        };
         Insert: {
-          genre_code: number
-          user_id?: string
-        }
+          genre_code: number;
+          user_id?: string;
+        };
         Update: {
-          genre_code?: number
-          user_id?: string
-        }
+          genre_code?: number;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "user_genres_genre_code_fkey"
-            columns: ["genre_code"]
-            isOneToOne: false
-            referencedRelation: "genres"
-            referencedColumns: ["code"]
+            foreignKeyName: "user_genres_genre_code_fkey";
+            columns: ["genre_code"];
+            isOneToOne: false;
+            referencedRelation: "genres";
+            referencedColumns: ["code"];
           },
           {
-            foreignKeyName: "user_genres_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "user_genres_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
-        ]
-      }
+        ];
+      };
       user_profile: {
         Row: {
-          created_at: string
-          description: string | null
-          id: string
-          nickname: string
-          profile_url: string | null
-        }
+          created_at: string;
+          description: string | null;
+          id: string;
+          nickname: string;
+          profile_url: string | null;
+        };
         Insert: {
-          created_at?: string
-          description?: string | null
-          id: string
-          nickname?: string
-          profile_url?: string | null
-        }
+          created_at?: string;
+          description?: string | null;
+          id: string;
+          nickname?: string;
+          profile_url?: string | null;
+        };
         Update: {
-          created_at?: string
-          description?: string | null
-          id?: string
-          nickname?: string
-          profile_url?: string | null
-        }
+          created_at?: string;
+          description?: string | null;
+          id?: string;
+          nickname?: string;
+          profile_url?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "user_profile_id_fkey"
-            columns: ["id"]
-            isOneToOne: true
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "user_profile_id_fkey";
+            columns: ["id"];
+            isOneToOne: true;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
-        ]
-      }
-    }
+        ];
+      };
+    };
     Views: {
       get_feeds_with_all: {
         Row: {
-          audio_url: string | null
-          author_id: string | null
-          author_nickname: string | null
-          author_profile_url: string | null
-          channel_id: string | null
-          content: string | null
-          created_at: string | null
-          feed_id: string | null
-          image_url: string | null
-          like_count: number | null
-          message_type: Database["public"]["Enums"]["message_type"] | null
-          title: string | null
-        }
+          audio_url: string | null;
+          author_id: string | null;
+          author_nickname: string | null;
+          author_profile_url: string | null;
+          channel_id: string | null;
+          content: string | null;
+          created_at: string | null;
+          feed_id: string | null;
+          image_url: string | null;
+          like_count: number | null;
+          message_type: Database["public"]["Enums"]["message_type"] | null;
+          title: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "feeds_channel_id_fkey"
-            columns: ["channel_id"]
-            isOneToOne: false
-            referencedRelation: "channels"
-            referencedColumns: ["id"]
+            foreignKeyName: "feeds_channel_id_fkey";
+            columns: ["channel_id"];
+            isOneToOne: false;
+            referencedRelation: "channels";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       get_feeds_with_user_and_likes: {
         Row: {
-          audio_url: string | null
-          author_id: string | null
-          author_nickname: string | null
-          author_profile_url: string | null
-          channel_id: string | null
-          content: string | null
-          created_at: string | null
-          feed_id: string | null
-          image_url: string | null
-          like_count: number | null
-          message_type: Database["public"]["Enums"]["message_type"] | null
-          title: string | null
-        }
+          audio_url: string | null;
+          author_id: string | null;
+          author_nickname: string | null;
+          author_profile_url: string | null;
+          channel_id: string | null;
+          content: string | null;
+          created_at: string | null;
+          feed_id: string | null;
+          image_url: string | null;
+          like_count: number | null;
+          message_type: Database["public"]["Enums"]["message_type"] | null;
+          title: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "feeds_author_id_fkey"
-            columns: ["author_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "feeds_author_id_fkey";
+            columns: ["author_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
           {
-            foreignKeyName: "feeds_channel_id_fkey"
-            columns: ["channel_id"]
-            isOneToOne: false
-            referencedRelation: "channels"
-            referencedColumns: ["id"]
+            foreignKeyName: "feeds_channel_id_fkey";
+            columns: ["channel_id"];
+            isOneToOne: false;
+            referencedRelation: "channels";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       get_replies_with_user: {
         Row: {
-          author_id: string | null
-          content: string | null
-          created_at: string | null
-          description: string | null
-          feed_id: string | null
-          feed_reply_id: string | null
-          nickname: string | null
-          profile_url: string | null
-        }
+          author_id: string | null;
+          content: string | null;
+          created_at: string | null;
+          description: string | null;
+          feed_id: string | null;
+          feed_reply_id: string | null;
+          nickname: string | null;
+          profile_url: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "feed_replies_author_id_fkey"
-            columns: ["author_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "feed_replies_author_id_fkey";
+            columns: ["author_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
           {
-            foreignKeyName: "feed_replies_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "feeds"
-            referencedColumns: ["id"]
+            foreignKeyName: "feed_replies_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "feeds";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "feed_replies_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["feed_id"]
+            foreignKeyName: "feed_replies_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["feed_id"];
           },
           {
-            foreignKeyName: "feed_replies_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_user_and_likes"
-            referencedColumns: ["feed_id"]
+            foreignKeyName: "feed_replies_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_user_and_likes";
+            referencedColumns: ["feed_id"];
           },
           {
-            foreignKeyName: "feed_replies_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "view_feed_search"
-            referencedColumns: ["id"]
+            foreignKeyName: "feed_replies_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "view_feed_search";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "feed_replies_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "view_feed_with_user"
-            referencedColumns: ["id"]
+            foreignKeyName: "feed_replies_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "view_feed_with_user";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       user_genre_details: {
         Row: {
-          genre_code: number | null
-          genre_name: string | null
-          user_id: string | null
-        }
+          genre_code: number | null;
+          genre_name: string | null;
+          user_id: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "user_genres_genre_code_fkey"
-            columns: ["genre_code"]
-            isOneToOne: false
-            referencedRelation: "genres"
-            referencedColumns: ["code"]
+            foreignKeyName: "user_genres_genre_code_fkey";
+            columns: ["genre_code"];
+            isOneToOne: false;
+            referencedRelation: "genres";
+            referencedColumns: ["code"];
           },
           {
-            foreignKeyName: "user_genres_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "user_genres_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
-        ]
-      }
+        ];
+      };
       view_channel_user_profiles: {
         Row: {
-          channel_id: string | null
-          created_at: string | null
-          description: string | null
-          id: string | null
-          nickname: string | null
-          profile_url: string | null
-        }
+          channel_id: string | null;
+          created_at: string | null;
+          description: string | null;
+          id: string | null;
+          nickname: string | null;
+          profile_url: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "user_channels_channel_id_fkey"
-            columns: ["channel_id"]
-            isOneToOne: false
-            referencedRelation: "channels"
-            referencedColumns: ["id"]
+            foreignKeyName: "user_channels_channel_id_fkey";
+            columns: ["channel_id"];
+            isOneToOne: false;
+            referencedRelation: "channels";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "user_profile_id_fkey"
-            columns: ["id"]
-            isOneToOne: true
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "user_profile_id_fkey";
+            columns: ["id"];
+            isOneToOne: true;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
-        ]
-      }
+        ];
+      };
       view_feed_search: {
         Row: {
-          audio_url: string | null
-          author_id: string | null
-          channel_id: string | null
-          content: string | null
-          created_at: string | null
-          id: string | null
-          image_url: string | null
-          like_count: number | null
-          message_type: Database["public"]["Enums"]["message_type"] | null
-          nickname: string | null
-          profile_url: string | null
-          title: string | null
-        }
+          audio_url: string | null;
+          author_id: string | null;
+          channel_id: string | null;
+          content: string | null;
+          created_at: string | null;
+          id: string | null;
+          image_url: string | null;
+          like_count: number | null;
+          message_type: Database["public"]["Enums"]["message_type"] | null;
+          nickname: string | null;
+          profile_url: string | null;
+          title: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "feeds_author_id_fkey"
-            columns: ["author_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "feeds_author_id_fkey";
+            columns: ["author_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
           {
-            foreignKeyName: "feeds_channel_id_fkey"
-            columns: ["channel_id"]
-            isOneToOne: false
-            referencedRelation: "channels"
-            referencedColumns: ["id"]
+            foreignKeyName: "feeds_channel_id_fkey";
+            columns: ["channel_id"];
+            isOneToOne: false;
+            referencedRelation: "channels";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       view_feed_with_user: {
         Row: {
-          audio_url: string | null
-          author_id: string | null
-          channel_id: string | null
-          content: string | null
-          created_at: string | null
-          id: string | null
-          image_url: string | null
-          message_type: Database["public"]["Enums"]["message_type"] | null
-          nickname: string | null
-          profile_url: string | null
-          title: string | null
-        }
+          audio_url: string | null;
+          author_id: string | null;
+          channel_id: string | null;
+          content: string | null;
+          created_at: string | null;
+          id: string | null;
+          image_url: string | null;
+          message_type: Database["public"]["Enums"]["message_type"] | null;
+          nickname: string | null;
+          profile_url: string | null;
+          title: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "feeds_author_id_fkey"
-            columns: ["author_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "feeds_author_id_fkey";
+            columns: ["author_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
           {
-            foreignKeyName: "feeds_channel_id_fkey"
-            columns: ["channel_id"]
-            isOneToOne: false
-            referencedRelation: "channels"
-            referencedColumns: ["id"]
+            foreignKeyName: "feeds_channel_id_fkey";
+            columns: ["channel_id"];
+            isOneToOne: false;
+            referencedRelation: "channels";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       view_notification_detail: {
         Row: {
-          created_at: string | null
-          feed_id: string | null
-          id: string | null
-          is_read: boolean | null
-          reply_id: string | null
-          sender_id: string | null
-          sender_nickname: string | null
-          sender_profile_url: string | null
-          type: string | null
-          user_id: string | null
-        }
+          created_at: string | null;
+          feed_id: string | null;
+          id: string | null;
+          is_read: boolean | null;
+          reply_id: string | null;
+          sender_id: string | null;
+          sender_nickname: string | null;
+          sender_profile_url: string | null;
+          type: string | null;
+          user_id: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "notifications_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "feeds"
-            referencedColumns: ["id"]
+            foreignKeyName: "notifications_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "feeds";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "notifications_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["feed_id"]
+            foreignKeyName: "notifications_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["feed_id"];
           },
           {
-            foreignKeyName: "notifications_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_user_and_likes"
-            referencedColumns: ["feed_id"]
+            foreignKeyName: "notifications_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_user_and_likes";
+            referencedColumns: ["feed_id"];
           },
           {
-            foreignKeyName: "notifications_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "view_feed_search"
-            referencedColumns: ["id"]
+            foreignKeyName: "notifications_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "view_feed_search";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "notifications_feed_id_fkey"
-            columns: ["feed_id"]
-            isOneToOne: false
-            referencedRelation: "view_feed_with_user"
-            referencedColumns: ["id"]
+            foreignKeyName: "notifications_feed_id_fkey";
+            columns: ["feed_id"];
+            isOneToOne: false;
+            referencedRelation: "view_feed_with_user";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "notifications_sender_id_fkey"
-            columns: ["sender_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "notifications_sender_id_fkey";
+            columns: ["sender_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
           {
-            foreignKeyName: "notifications_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "notifications_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
-        ]
-      }
+        ];
+      };
       view_user_channels: {
         Row: {
-          channel_created_at: string | null
-          channel_description: string | null
-          channel_id: string | null
-          channel_name: string | null
-          owner_id: string | null
-          user_id: string | null
-        }
+          channel_created_at: string | null;
+          channel_description: string | null;
+          channel_id: string | null;
+          channel_name: string | null;
+          owner_id: string | null;
+          user_id: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "channels_owner_id_fkey"
-            columns: ["owner_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "channels_owner_id_fkey";
+            columns: ["owner_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
           {
-            foreignKeyName: "user_channels_channel_id_fkey"
-            columns: ["channel_id"]
-            isOneToOne: false
-            referencedRelation: "channels"
-            referencedColumns: ["id"]
+            foreignKeyName: "user_channels_channel_id_fkey";
+            columns: ["channel_id"];
+            isOneToOne: false;
+            referencedRelation: "channels";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "user_channels_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "user_channels_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
-        ]
-      }
+        ];
+      };
       view_user_genres: {
         Row: {
-          genre_code: number | null
-          genre_created_at: string | null
-          genre_name: string | null
-          user_id: string | null
-        }
+          genre_code: number | null;
+          genre_created_at: string | null;
+          genre_name: string | null;
+          user_id: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "user_genres_genre_code_fkey"
-            columns: ["genre_code"]
-            isOneToOne: false
-            referencedRelation: "genres"
-            referencedColumns: ["code"]
+            foreignKeyName: "user_genres_genre_code_fkey";
+            columns: ["genre_code"];
+            isOneToOne: false;
+            referencedRelation: "genres";
+            referencedColumns: ["code"];
           },
           {
-            foreignKeyName: "user_genres_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "get_feeds_with_all"
-            referencedColumns: ["author_id"]
+            foreignKeyName: "user_genres_user_id_fkey";
+            columns: ["user_id"];
+            isOneToOne: false;
+            referencedRelation: "get_feeds_with_all";
+            referencedColumns: ["author_id"];
           },
-        ]
-      }
-    }
+        ];
+      };
+    };
     Functions: {
       create_channel_and_link_user: {
-        Args: { name: string; description?: string; genre_code?: number }
-        Returns: string
-      }
+        Args: { name: string; description?: string; genre_code?: number };
+        Returns: string;
+      };
+      delete_feed: {
+        Args: { p_feed_id: string };
+        Returns: {
+          data: Json;
+          error: string;
+        }[];
+      };
       get_feeds_near_view: {
-        Args: { target_feed_id: string; offset_count?: number }
+        Args: { target_feed_id: string; offset_count?: number };
         Returns: {
-          audio_url: string | null
-          author_id: string | null
-          author_nickname: string | null
-          author_profile_url: string | null
-          channel_id: string | null
-          content: string | null
-          created_at: string | null
-          feed_id: string | null
-          image_url: string | null
-          like_count: number | null
-          message_type: Database["public"]["Enums"]["message_type"] | null
-          title: string | null
-        }[]
-      }
+          audio_url: string | null;
+          author_id: string | null;
+          author_nickname: string | null;
+          author_profile_url: string | null;
+          channel_id: string | null;
+          content: string | null;
+          created_at: string | null;
+          feed_id: string | null;
+          image_url: string | null;
+          like_count: number | null;
+          message_type: Database["public"]["Enums"]["message_type"] | null;
+          title: string | null;
+        }[];
+      };
       update_user_genres: {
-        Args: { user_id: string; selected_genres: number[] }
+        Args: { user_id: string; selected_genres: number[] };
         Returns: {
-          data: boolean
-          error: string
-        }[]
-      }
-    }
+          data: boolean;
+          error: string;
+        }[];
+      };
+    };
     Enums: {
-      message_type: "default" | "clip" | "image"
-    }
+      message_type: "default" | "clip" | "image";
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-}
+      [_ in never]: never;
+    };
+  };
+};
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+type DefaultSchema = DatabaseWithoutInternals[Extract<
+  keyof Database,
+  "public"
+>];
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
     | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
         DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
       DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
+      Row: infer R;
     }
     ? R
     : never
@@ -874,95 +884,95 @@ export type Tables<
         DefaultSchema["Views"])
     ? (DefaultSchema["Tables"] &
         DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R
+        Row: infer R;
       }
       ? R
       : never
-    : never
+    : never;
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
+      Insert: infer I;
     }
     ? I
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
     ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I
+        Insert: infer I;
       }
       ? I
       : never
-    : never
+    : never;
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
+      Update: infer U;
     }
     ? U
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
     ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U
+        Update: infer U;
       }
       ? U
       : never
-    : never
+    : never;
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
     | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
     ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-    : never
+    : never;
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
     | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
   : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
     ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never
+    : never;
 
 export const Constants = {
   public: {
@@ -970,4 +980,4 @@ export const Constants = {
       message_type: ["default", "clip", "image"],
     },
   },
-} as const
+} as const;

--- a/src/api/channels.ts
+++ b/src/api/channels.ts
@@ -69,3 +69,17 @@ export const addChannels = async ({
     return data;
   }
 };
+
+export const getChannelCreateUser = async (channel_id: string) => {
+  const { data, error } = await supabase
+    .from("channels")
+    .select("owner_id")
+    .eq("id", channel_id);
+
+  if (error) {
+    errorHandler(error, "getChannelCreateUser");
+    return null;
+  } else {
+    return data;
+  }
+};

--- a/src/api/feeds.ts
+++ b/src/api/feeds.ts
@@ -201,13 +201,11 @@ export const getFeedsByChannelAndAfter = async (
   }
 };
 
-export const getFeedByTargetId = async (
-  feedId: string,
-) => {
-  const { data, error } = await supabase.
-  from("get_feeds_with_user_and_likes")
-  .select("*")
-  .eq("feed_id", feedId)
+export const getFeedByTargetId = async (feedId: string) => {
+  const { data, error } = await supabase
+    .from("get_feeds_with_user_and_likes")
+    .select("*")
+    .eq("feed_id", feedId);
 
   if (error) {
     errorHandler(error, "getFeedsByChannelAndNear");
@@ -348,21 +346,33 @@ export const getPopularClips = async (): Promise<
 
 /**
  * @description 인기 피드(message_type이 default)
- * @returns 인기 피드 리스트 
+ * @returns 인기 피드 리스트
  */
-export const getPopularFeeds = async ():Promise<
-  Tables<"get_feeds_with_user_and_likes">[]|null
-  > =>{
-  const {data,error} = await supabase
-  .from("get_feeds_with_user_and_likes")
-  .select("*")
-  .eq("message_type", "default")
-  .order("like_count",{ascending:false})
-  .limit(10);
+export const getPopularFeeds = async (): Promise<
+  Tables<"get_feeds_with_user_and_likes">[] | null
+> => {
+  const { data, error } = await supabase
+    .from("get_feeds_with_user_and_likes")
+    .select("*")
+    .eq("message_type", "default")
+    .order("like_count", { ascending: false })
+    .limit(10);
 
-  if(error){
-    errorHandler(error,"getPopularFeeds");
+  if (error) {
+    errorHandler(error, "getPopularFeeds");
     return null;
   }
   return data;
-}
+};
+
+export const deleteFeed = async (feedId: string) => {
+  const { data, error } = await supabase.rpc("delete_feed", {
+    p_feed_id: feedId,
+  });
+
+  if (error) {
+    errorHandler(error, "deleteFeed");
+    return null;
+  }
+  return data;
+};

--- a/src/api/replies.ts
+++ b/src/api/replies.ts
@@ -29,7 +29,8 @@ export const getRepliesWithUserInfo = async (
   const { data, error } = await supabase
     .from("get_replies_with_user")
     .select("*")
-    .eq("feed_id", feedId);
+    .eq("feed_id", feedId)
+    .order("created_at", { ascending: true });
 
   if (error) {
     errorHandler(error, "getRepliesWithUserInfo");
@@ -59,6 +60,20 @@ export const addReply = async ({
 
   if (error) {
     errorHandler(error, "addReply");
+    return null;
+  } else {
+    return data;
+  }
+};
+
+export const deleteReply = async (feedReplyId: string) => {
+  const { data, error } = await supabase
+    .from("feed_replies")
+    .delete()
+    .eq("id", feedReplyId)
+    .select();
+  if (error) {
+    errorHandler(error, "deleteReply");
     return null;
   } else {
     return data;

--- a/src/pages/Channel/Channel.module.css
+++ b/src/pages/Channel/Channel.module.css
@@ -1,6 +1,6 @@
 .contentArea {
   height: 100%;
-  padding: var(--spacing-12);
+  padding: 0 var(--spacing-12);
   overflow-y: auto;
   display: flex;
   flex-direction: column;
@@ -126,6 +126,14 @@
   }
 }
 
-.observerDiv{
+.observerDiv {
   height: 10px;
+}
+
+.noFeed {
+  display: flex;
+  justify-content: center;
+  padding: 3rem;
+  color: var(--gray_10);
+  flex: 1;
 }

--- a/src/pages/Channel/components/ChannelFeed.module.css
+++ b/src/pages/Channel/components/ChannelFeed.module.css
@@ -22,7 +22,7 @@
     }
   }
   .messageFeed {
-    flex: 1;
+    flex: 0.85;
     display: flex;
     flex-direction: column;
     gap: var(--spacing-12);
@@ -86,6 +86,14 @@
 
       &:hover {
         background-color: var(--primary_active);
+      }
+    }
+    button.deleteButton {
+      background-color: var(--gray_04);
+      color: var(--gray_10);
+
+      &:hover {
+        background-color: var(--gray_03);
       }
     }
   }

--- a/src/pages/Channel/components/ChannelFeedAudio.tsx
+++ b/src/pages/Channel/components/ChannelFeedAudio.tsx
@@ -4,6 +4,7 @@ import CustomAudioPlayer from "@/components/CustomAudioPlayer";
 import type React from "react";
 import heartEmpty from "@/assets/heart_empty.svg";
 import heartFilled from "@/assets/heart_filled.svg";
+import { useAuth } from "@/auth/AuthProvider";
 import { timeFormater } from "@/utils/timeFormatter";
 import { useRouter } from "@/router/RouterProvider";
 interface Props {
@@ -12,6 +13,7 @@ interface Props {
   isActive: boolean;
   isUserLike: boolean;
   onToggleLike: (feedId: string) => void;
+  handleDelete: (feedId: string) => void;
 }
 
 function ChannelFeedAudio({
@@ -31,11 +33,13 @@ function ChannelFeedAudio({
   isActive,
   isUserLike,
   onToggleLike,
+  handleDelete,
 }: Props) {
+  const { user } = useAuth();
   const { setHistoryRoute } = useRouter();
 
   const handleClick = (userId: string | null) => {
-    if(!userId) return;
+    if (!userId) return;
     window.history.pushState(null, "", `/user/${userId}`);
     setHistoryRoute(`/user/${userId}`);
   };
@@ -46,8 +50,10 @@ function ChannelFeedAudio({
     onReplyClicked();
   };
   const kst = timeFormater(created_at!);
-  const createdTime =
-    kst!.slice(0, 10) + " " + kst!.slice(11, 16);
+  const createdTime = kst!.slice(0, 10) + " " + kst!.slice(11, 16);
+  const handleDeleteFeed = () => {
+    handleDelete(feed_id);
+  };
   return (
     <div
       id={feed_id}
@@ -58,15 +64,12 @@ function ChannelFeedAudio({
           className={S.userAvatar}
           src={preview_url ? preview_url : "/music_mate_symbol_fixed.svg"}
           alt="작성자프로필이미지"
-          onClick={()=> handleClick(author_id)}
-          style={{cursor: "pointer"}}
+          onClick={() => handleClick(author_id)}
+          style={{ cursor: "pointer" }}
         />
       </div>
       <div className={S.messageFeed}>
-        <p
-          onClick={()=> handleClick(author_id)}
-          style={{cursor: "pointer"}}
-        >
+        <p onClick={() => handleClick(author_id)} style={{ cursor: "pointer" }}>
           {author_nickname} <small>{createdTime}</small>
         </p>
         {title ? <h3>{title}</h3> : null}
@@ -107,6 +110,15 @@ function ChannelFeedAudio({
         <button type="button" onClick={handleReplyClicked}>
           댓글
         </button>
+        {author_id === user?.id ? (
+          <button
+            type="button"
+            className={S.deleteButton}
+            onClick={handleDeleteFeed}
+          >
+            삭제
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/src/pages/Channel/components/ChannelFeedMessage.tsx
+++ b/src/pages/Channel/components/ChannelFeedMessage.tsx
@@ -5,12 +5,14 @@ import heartEmpty from "@/assets/heart_empty.svg";
 import heartFilled from "@/assets/heart_filled.svg";
 import { timeFormater } from "@/utils/timeFormatter";
 import { useRouter } from "@/router/RouterProvider";
+import { useAuth } from "@/auth/AuthProvider";
 interface Props {
   feedItem: Tables<"get_feeds_with_user_and_likes"> & { preview_url?: string };
   onReplyClicked: () => void;
   isActive: boolean;
   isUserLike: boolean;
   onToggleLike: (feedId: string) => void;
+  handleDelete: (feedId: string) => void;
 }
 
 function ChannelFeedMessage({
@@ -28,24 +30,28 @@ function ChannelFeedMessage({
   isActive,
   isUserLike,
   onToggleLike,
+  handleDelete,
 }: Props) {
+  const { user } = useAuth();
   const { setHistoryRoute } = useRouter();
 
   const handleClick = (userId: string | null) => {
-    if(!userId) return;
+    if (!userId) return;
     window.history.pushState(null, "", `/user/${userId}`);
     setHistoryRoute(`/user/${userId}`);
   };
-  
 
   if (!feed_id) return;
   const handleReplyClicked = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     onReplyClicked();
   };
+
+  const handleDeleteFeed = () => {
+    handleDelete(feed_id);
+  };
   const kst = timeFormater(created_at!);
-  const createdTime =
-    kst!.slice(0, 10) + " " + kst!.slice(11, 16);
+  const createdTime = kst!.slice(0, 10) + " " + kst!.slice(11, 16);
 
   return (
     <div
@@ -57,15 +63,12 @@ function ChannelFeedMessage({
           className={S.userAvatar}
           src={preview_url ? preview_url : "/music_mate_symbol_fixed.svg"}
           alt="작성자프로필이미지"
-          onClick={()=> handleClick(author_id)}
-          style={{cursor: "pointer"}}
+          onClick={() => handleClick(author_id)}
+          style={{ cursor: "pointer" }}
         />
       </div>
       <div className={S.messageFeed}>
-        <p
-          onClick={()=> handleClick(author_id)}
-          style={{cursor: "pointer"}}
-        >
+        <p onClick={() => handleClick(author_id)} style={{ cursor: "pointer" }}>
           {author_nickname} <small>{createdTime}</small>
         </p>
         {image_url ? (
@@ -93,6 +96,15 @@ function ChannelFeedMessage({
         <button type="button" onClick={handleReplyClicked}>
           댓글
         </button>
+        {author_id === user?.id ? (
+          <button
+            type="button"
+            className={S.deleteButton}
+            onClick={handleDeleteFeed}
+          >
+            삭제
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/src/pages/Channel/components/DetailContents.module.css
+++ b/src/pages/Channel/components/DetailContents.module.css
@@ -30,10 +30,27 @@
       gap: var(--spacing-12);
       justify-content: center;
 
-      button {
-        padding: 8px;
-        border-radius: 8px;
-        background-color: var(--primary_default);
+      .messageFeedButtons {
+        display: flex;
+        gap: var(--spacing-12);
+        button {
+          padding: 8px;
+          border-radius: 8px;
+          background-color: var(--primary_default);
+          cursor: pointer;
+
+          &:hover {
+            background-color: var(--primary_active);
+          }
+        }
+        .deleteButton {
+          background-color: var(--gray_04);
+          color: var(--gray_10);
+
+          &:hover {
+            background-color: var(--gray_03);
+          }
+        }
       }
     }
   }
@@ -52,6 +69,7 @@
       justify-content: center;
       align-items: center;
       gap: var(--spacing-4);
+      cursor: pointer;
     }
   }
 }
@@ -67,37 +85,71 @@
 
     .reply {
       display: flex;
+      justify-content: space-between;
       width: 100%;
       gap: var(--spacing-12);
       position: relative;
       color: var(--white);
       padding: 0.5rem;
 
-      .userAvatarContainer {
+      .replyContents {
         display: flex;
-        flex-direction: column;
-        align-items: center;
+        width: 100%;
+        gap: var(--spacing-12);
+        position: relative;
+        color: var(--white);
 
-        .userAvatar {
-          border-radius: 50%;
-          width: 50px;
-          height: 50px;
-          border: 1px solid var(--gray_08);
-          padding: 0.5rem;
+        .userAvatarContainer {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+
+          .userAvatar {
+            border-radius: 50%;
+            width: 50px;
+            height: 50px;
+            border: 1px solid var(--gray_08);
+            padding: 0.5rem;
+          }
+        }
+        .messageFeed {
+          display: flex;
+          flex-direction: column;
+          gap: var(--spacing-12);
+          justify-content: center;
+
+          button {
+            padding: 8px;
+            border-radius: 8px;
+            background-color: var(--primary_default);
+          }
         }
       }
-      .messageFeed {
+      .deleteButton {
+        font-weight: bold;
+        padding: 8px;
+        border-radius: 8px;
         display: flex;
-        flex-direction: column;
-        gap: var(--spacing-12);
         justify-content: center;
+        align-items: center;
+        gap: var(--spacing-4);
+        height: 32px;
+        cursor: pointer;
+        background-color: var(--gray_04);
+        color: var(--gray_10);
 
-        button {
-          padding: 8px;
-          border-radius: 8px;
-          background-color: var(--primary_default);
+        &:hover {
+          background-color: var(--gray_03);
         }
       }
     }
   }
+}
+
+.noReply {
+  display: flex;
+  justify-content: center;
+  padding: 2rem;
+  color: var(--gray_10);
+  flex: 1;
 }

--- a/src/pages/Channel/components/DetailFeeds.tsx
+++ b/src/pages/Channel/components/DetailFeeds.tsx
@@ -3,6 +3,7 @@ import S from "./DetailContents.module.css";
 import heartEmpty from "@/assets/heart_empty_white.svg";
 import heartFilled from "@/assets/heart_filled_white.svg";
 import { useRouter } from "@/router/RouterProvider";
+import { useAuth } from "@/auth/AuthProvider";
 
 interface Props {
   feedItem: Tables<"get_feeds_with_user_and_likes"> & { preview_url?: string };
@@ -10,6 +11,7 @@ interface Props {
   onToggleLike: (feedId: string) => void;
   isUserLike: boolean;
   scrollToSelectedFeed: () => void;
+  handleDelete: (feedId: string) => void;
 }
 
 function DetailFeeds({
@@ -18,17 +20,22 @@ function DetailFeeds({
   onToggleLike,
   isUserLike,
   scrollToSelectedFeed,
+  handleDelete,
 }: Props) {
   const { setHistoryRoute } = useRouter();
-  
+  const { user } = useAuth();
+
   const handleClick = (userId: string | null) => {
-    if(!userId) return;
+    if (!userId) return;
     window.history.pushState(null, "", `/user/${userId}`);
     setHistoryRoute(`/user/${userId}`);
   };
 
   const handleLikeToggle = () => {
     onToggleLike(feed_id!);
+  };
+  const handleDeleteFeed = () => {
+    handleDelete(feed_id!);
   };
 
   return (
@@ -39,20 +46,31 @@ function DetailFeeds({
             className={S.userAvatar}
             src={preview_url ? preview_url : "/music_mate_symbol_fixed.svg"}
             alt="작성자프로필이미지"
-            onClick={()=> handleClick(author_id)}
-            style={{cursor: "pointer"}}
+            onClick={() => handleClick(author_id)}
+            style={{ cursor: "pointer" }}
           />
         </div>
         <div className={S.messageFeed}>
           <p
-            onClick={()=> handleClick(author_id)}
-            style={{cursor: "pointer"}}
+            onClick={() => handleClick(author_id)}
+            style={{ cursor: "pointer" }}
           >
-          {author_nickname}
+            {author_nickname}
           </p>
-          <button type="button" onClick={scrollToSelectedFeed}>
-            현재 게시물로 돌아가기
-          </button>
+          <div className={S.messageFeedButtons}>
+            <button type="button" onClick={scrollToSelectedFeed}>
+              현재 게시물로 돌아가기
+            </button>
+            {author_id === user?.id ? (
+              <button
+                type="button"
+                className={S.deleteButton}
+                onClick={handleDeleteFeed}
+              >
+                삭제
+              </button>
+            ) : null}
+          </div>
         </div>
       </div>
       <div className={S.reactsInfo}>

--- a/src/pages/Channel/components/FeedReplies.tsx
+++ b/src/pages/Channel/components/FeedReplies.tsx
@@ -3,16 +3,24 @@ import S from "./DetailContents.module.css";
 import FeedReply from "./FeedReply";
 interface Props {
   replies: Tables<"get_replies_with_user">[] | null;
+  handleDeleteReply: (feedReplyId: string) => void;
+  replyContainerRef: React.RefObject<HTMLDivElement | null>;
 }
-function FeedReplies({ replies }: Props) {
+function FeedReplies({ replies, handleDeleteReply, replyContainerRef }: Props) {
   return (
-    <div className={S.replyContainer}>
+    <div className={S.replyContainer} ref={replyContainerRef}>
       <ul className={S.replies}>
-        {replies
-          ? replies?.map((reply) => (
-              <FeedReply key={reply.feed_reply_id} reply={reply} />
-            ))
-          : null}
+        {replies?.length === 0 ? (
+          <div className={S.noReply}>댓글이 없습니다</div>
+        ) : (
+          replies?.map((reply) => (
+            <FeedReply
+              key={reply.feed_reply_id}
+              reply={reply}
+              handleDeleteReply={handleDeleteReply}
+            />
+          ))
+        )}
       </ul>
     </div>
   );

--- a/src/pages/Channel/components/FeedReply.tsx
+++ b/src/pages/Channel/components/FeedReply.tsx
@@ -3,21 +3,32 @@ import S from "./DetailContents.module.css";
 import { useEffect, useState } from "react";
 import { getAvatarUrlPreview } from "@/api/user_avatar";
 import { useRouter } from "@/router/RouterProvider";
+import { useAuth } from "@/auth/AuthProvider";
+import { timeFormater } from "@/utils/timeFormatter";
 interface Props {
   reply: Tables<"get_replies_with_user">;
+  handleDeleteReply: (feedReplyId: string) => void;
 }
 
-function FeedReply({ reply }: Props) {
-  const { content, created_at, nickname, profile_url, feed_reply_id, author_id } = reply;
+function FeedReply({ reply, handleDeleteReply }: Props) {
+  const {
+    content,
+    created_at,
+    nickname,
+    profile_url,
+    feed_reply_id,
+    author_id,
+  } = reply;
   const { setHistoryRoute } = useRouter();
-  
+  const { user } = useAuth();
+
   const handleClick = (userId: string | null) => {
-    if(!userId) return;
+    if (!userId) return;
     window.history.pushState(null, "", `/user/${userId}`);
     setHistoryRoute(`/user/${userId}`);
   };
-  const createdTime =
-    created_at!.slice(0, 10) + " " + created_at!.slice(11, 16);
+  const kst = timeFormater(created_at!);
+  const createdTime = kst!.slice(0, 10) + " " + kst!.slice(11, 16);
 
   const [profilePreview, setProfilePreview] = useState("");
   useEffect(() => {
@@ -28,29 +39,45 @@ function FeedReply({ reply }: Props) {
     };
     getImageUrl();
   }, [profile_url]);
+
+  const onDeleteReply = () => {
+    handleDeleteReply(feed_reply_id!);
+  };
+
   if (feed_reply_id)
     return (
       <li className={S.reply} key={feed_reply_id} id={feed_reply_id}>
-        <div className={S.userAvatarContainer}>
-          <img
-            className={S.userAvatar}
-            src={
-              profilePreview ? profilePreview : "/music_mate_symbol_fixed.svg"
-            }
-            alt="작성자"
-            onClick={()=> handleClick(author_id)}
-            style={{cursor: "pointer"}} 
-          />
+        <div className={S.replyContents}>
+          <div className={S.userAvatarContainer}>
+            <img
+              className={S.userAvatar}
+              src={
+                profilePreview ? profilePreview : "/music_mate_symbol_fixed.svg"
+              }
+              alt="작성자"
+              onClick={() => handleClick(author_id)}
+              style={{ cursor: "pointer" }}
+            />
+          </div>
+          <div className={S.messageFeed}>
+            <p
+              onClick={() => handleClick(author_id)}
+              style={{ cursor: "pointer" }}
+            >
+              {nickname} <small>{createdTime}</small>
+            </p>
+            <p>{content}</p>
+          </div>
         </div>
-        <div className={S.messageFeed}>
-          <p
-            onClick={()=> handleClick(author_id)}
-            style={{cursor: "pointer"}}
+        {author_id === user?.id ? (
+          <button
+            type="button"
+            className={S.deleteButton}
+            onClick={onDeleteReply}
           >
-            {nickname} <small>{createdTime}</small>
-          </p>
-          <p>{content}</p>
-        </div>
+            삭제
+          </button>
+        ) : null}
       </li>
     );
 }

--- a/src/pages/Channel/components/InputFeed.tsx
+++ b/src/pages/Channel/components/InputFeed.tsx
@@ -63,6 +63,7 @@ function InputFeed({
     if (text) {
       text.value = "";
       text.focus();
+      text.style.height = "auto";
     }
     setImage(undefined);
     setImagePreview(undefined);
@@ -79,12 +80,12 @@ function InputFeed({
 
     const text = textareaRef.current;
     if (!isAuth) {
-      alert("채널에 메세지를 보내려면 로그인해야 합니다.");
+      alert("로그인 후에 글을 올릴 수 있습니다.");
       return;
     }
 
     if (!isMember) {
-      alert("채널에 메세지를 보내려면 멤버여야 합니다.");
+      alert("채널에 가입한 후에 글을 올릴 수 있습니다.");
       return;
     }
 
@@ -159,7 +160,6 @@ function InputFeed({
         setRecordingData={setRecordingData}
         curChannelId={curChannelId}
         handleAddSubmitFeed={handleAddSubmitFeed}
-        
       />
 
       {/* 이미지 프리뷰 영역 */}

--- a/src/pages/Channel/components/InputReplies.tsx
+++ b/src/pages/Channel/components/InputReplies.tsx
@@ -9,8 +9,13 @@ import { alert } from "@/components/common/CustomAlert";
 interface Props {
   currentFeedId: string;
   setUpdateReplies: (time: number) => void;
+  scrollToBottom: () => void;
 }
-function InputReplies({ currentFeedId, setUpdateReplies }: Props) {
+function InputReplies({
+  currentFeedId,
+  setUpdateReplies,
+  scrollToBottom,
+}: Props) {
   const { isAuth, user } = useAuth();
   const { id: channelId } = useParams();
   const [isMember, setIsMember] = useState<boolean | null>(false);
@@ -18,6 +23,10 @@ function InputReplies({ currentFeedId, setUpdateReplies }: Props) {
 
   // Id
   const submitBtnId = useId();
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
 
   useEffect(() => {
     async function check() {
@@ -32,7 +41,14 @@ function InputReplies({ currentFeedId, setUpdateReplies }: Props) {
 
   const initialize = () => {
     const text = textareaRef.current;
-    if (text) text.value = "";
+    if (text) {
+      text.value = "";
+      text.focus();
+      text.style.height = "auto";
+      requestAnimationFrame(() => {
+        scrollToBottom();
+      });
+    }
   };
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -40,13 +56,13 @@ function InputReplies({ currentFeedId, setUpdateReplies }: Props) {
     const text = textareaRef.current;
 
     if (!isAuth) {
-      alert("피드에 댓글을 작성하려면 로그인해야 합니다.");
+      alert("로그인 후에 댓글을 작성할 수 있습니다.");
       if (text) text.value = "";
       return;
     }
 
     if (!isMember) {
-      alert("채널에 메세지를 보내려면 멤버여야 합니다.");
+      alert("채널에 가입한 후에 댓글을 작성할 수 있습니다.");
       if (text) text.value = "";
       return;
     }

--- a/src/pages/NotFound/NotFound.module.css
+++ b/src/pages/NotFound/NotFound.module.css
@@ -22,16 +22,17 @@
   }
 
   a {
-    color: var(--black);
+    color: var(--gray_02);
     background-color: var(--primary_default);
     font-weight: bold;
-    padding: 8px;
-    border-radius: 8px;
+    padding: 0 1rem;
+    border-radius: 20px;
+    margin: 6px 10px;
     display: flex;
     justify-content: center;
     align-items: center;
     gap: var(--spacing-4);
-    height: 32px;
+    height: 40px;
     cursor: pointer;
     text-decoration: none;
 


### PR DESCRIPTION
## 작업 개요
채널 피드와 댓글 삭제 기능을 구현했습니다.
UX 개선을 위해 안내 문구 등을 추가했습니다.

## 작업 내용
🛠️ 기능
- [x] 피드 삭제 rpc 구현(좋아요/댓글/피드 다 삭제하기 위해서) -> 피드 삭제 기능 구현
- [x] 채널 만든 사람 가져오는 API 구현 -> 채널탈퇴하기 버튼 눌렀을 때 채널 생성자는 탈퇴하지 못하도록 제한
- [x] 댓글 시간순으로 정렬해서 받아오도록 수정, 댓글 작성시간 한국 기준으로 수정, 댓글 스크롤 이동 추가
- [x] 댓글 삭제 API 구현 -> 댓글 삭제 기능 구현

🛠️ 기타
- [x] 피드/댓글 작성자에게만 삭제버튼 보이도록 구현
- [x] 피드/댓글 없을 경우 안내문구 추가
- [x] 피드/댓글 입력창에서 몇 줄짜리 보내고 나면 다시 작성하기 전까지 height가 원래대로 줄어들지 않아서 수정했습니다 
- [x] notFound, 회원 전용 안내페이지 버튼 css 변경 (login 버튼과 동일하게 변경)

## 관련 이슈
Closes #81 

## 테스트 결과 보고
