### PR TITLE
[Feat] 생성시간에도 이벤트 적용되는 거 없애기

### DIFF
--- a/src/pages/Channel/components/ChannelFeedAudio.tsx
+++ b/src/pages/Channel/components/ChannelFeedAudio.tsx
@@ -69,8 +69,11 @@ function ChannelFeedAudio({
         />
       </div>
       <div className={S.messageFeed}>
-        <p onClick={() => handleClick(author_id)} style={{ cursor: "pointer" }}>
-          {author_nickname} <small>{createdTime}</small>
+        <p>
+          <span onClick={() => handleClick(author_id)} style={{ cursor: "pointer" }}>
+            {author_nickname}
+          </span>
+           <small style={{ marginLeft: "4px" }}>{createdTime}</small>
         </p>
         {title ? <h3>{title}</h3> : null}
         <div className={S.audioPlayerAndImg}>

--- a/src/pages/Channel/components/ChannelFeedMessage.tsx
+++ b/src/pages/Channel/components/ChannelFeedMessage.tsx
@@ -68,8 +68,11 @@ function ChannelFeedMessage({
         />
       </div>
       <div className={S.messageFeed}>
-        <p onClick={() => handleClick(author_id)} style={{ cursor: "pointer" }}>
-          {author_nickname} <small>{createdTime}</small>
+        <p>
+          <span onClick={() => handleClick(author_id)} style={{ cursor: "pointer" }}>
+            {author_nickname}
+          </span>
+           <small style={{ marginLeft: "4px" }}>{createdTime}</small>
         </p>
         {image_url ? (
           <div className={S.imgContainer}>

--- a/src/pages/Channel/components/FeedReply.tsx
+++ b/src/pages/Channel/components/FeedReply.tsx
@@ -60,12 +60,12 @@ function FeedReply({ reply, handleDeleteReply }: Props) {
             />
           </div>
           <div className={S.messageFeed}>
-            <p
-              onClick={() => handleClick(author_id)}
-              style={{ cursor: "pointer" }}
-            >
-              {nickname} <small>{createdTime}</small>
-            </p>
+          <p>
+            <span onClick={() => handleClick(author_id)} style={{ cursor: "pointer" }}>
+              {nickname}
+            </span>
+            <small style={{ marginLeft: "4px" }}>{createdTime}</small>
+          </p>
             <p>{content}</p>
           </div>
         </div>


### PR DESCRIPTION
## 작업 개요
피드메시지들에서 생성시간에도 마우스 이벤트 적용되는거 수정했습니다.

## 작업 내용
- [x] 작성자 닉네임만 span태그로 감싸기


## 관련 이슈

## 테스트 결과 보고
사용자 프로필과 닉네임 클릭시에만 프로필페이지로 이동합니다.