### PR TITLE
[Feat]오디오팝업 오버레이 삭제 & escape 키다운 추가

### DIFF
--- a/src/pages/Main/components/ClipSwiper.tsx
+++ b/src/pages/Main/components/ClipSwiper.tsx
@@ -33,6 +33,21 @@ function ClipSwiper() {
     fetchClips();
   },[]);
 
+  useEffect(()=>{
+    const handlekeyDown = (e:KeyboardEvent) => {
+      if(e.key === "Escape"){
+        setSelectedAudio(null);
+      }
+    };
+
+    if(selectedAudio){
+      document.addEventListener("keydown",handlekeyDown);
+    }
+    return () => {
+      document.removeEventListener("keydown",handlekeyDown);
+    };
+  },[selectedAudio]);
+
 
   return (
     <>
@@ -95,10 +110,6 @@ function ClipSwiper() {
 
 
     {selectedAudio && (
-      <div
-        className={S.audioOverlay}
-        onClick={()=> setSelectedAudio(null)}
-      >
       <div className={S.audioPopup} onClick={(e) => e.stopPropagation()}>
         <button 
           className={S.closeButton} 
@@ -112,7 +123,7 @@ function ClipSwiper() {
           </ChannelLink>
         </div>
         </div>
-      </div>
+
     )}
     </>
   )


### PR DESCRIPTION
## 작업 개요
오디오 팝업 시 배경 오버레이 없앴습니다.
esc 키로 팝업 닫을 수 있게 했습니다.

## 작업 내용
- [x] overlay 삭제 
- [x] handleKeydown으로 esc 키다운 이벤트 추가

## 관련 이슈

## 테스트 결과 보고
