### PR TITLE
[Feat, Design] 채널피드에 토글메뉴추가[삭제/공유]

### DIFF
--- a/src/assets/more_button.svg
+++ b/src/assets/more_button.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="32px" height="32px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="6" r="1.5" fill="#F9BB04"/>
+<circle cx="12" cy="12" r="1.5" fill="#F9BB04"/>
+<circle cx="12" cy="18" r="1.5" fill="#F9BB04"/>
+</svg>

--- a/src/pages/Channel/components/ChannelFeed.module.css
+++ b/src/pages/Channel/components/ChannelFeed.module.css
@@ -88,12 +88,64 @@
         background-color: var(--primary_active);
       }
     }
-    button.deleteButton {
-      background-color: var(--gray_04);
-      color: var(--gray_10);
 
-      &:hover {
-        background-color: var(--gray_03);
+    .dropdownWrapper {
+      button {
+        background-color: var(--background);
+        padding: var(--spacing-4) 0;
+        position: relative;
+        display: inline-block;
+      }
+
+      .dropdownList {
+        display: flex;
+        align-items: center;
+        position: absolute;
+        right: -16px;
+        bottom: 100%;
+        background-color: var(--gray_04);
+        list-style: none;
+        margin-bottom: 8px;
+        box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+        z-index: 100;
+        color: var(--white);
+        height: fit-content;
+        width: fit-content;
+        border-radius: 10px;
+
+        li {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+        }
+
+        li button {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          background-color: var(--gray_04);
+          color: var(--white);
+          white-space: nowrap;
+          border-radius: 10px;
+          padding: 12px;
+          font-weight: normal;
+          transition: color 0.4s ease;
+        }
+
+        li button:hover {
+          color: var(--primary_active);
+          font-weight: bold;
+        }
+
+        li button.deleteButton {
+          border-radius: 10px 0 0 10px;
+          border-right: 1px solid var(--gray_06);
+
+          &.disabled {
+            color: var(--gray_05);
+            cursor: default;
+          }
+        }
       }
     }
   }
@@ -133,13 +185,18 @@ h3 small {
 }
 
 .skeleton::before {
-  content: '';
+  content: "";
   position: absolute;
   top: 0;
   left: -100%;
   width: 100%;
   height: 100%;
-  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.2),
+    transparent
+  );
   animation: shimmer 1.5s infinite;
 }
 

--- a/src/pages/Channel/components/ChannelFeedMessage.tsx
+++ b/src/pages/Channel/components/ChannelFeedMessage.tsx
@@ -6,6 +6,9 @@ import heartFilled from "@/assets/heart_filled.svg";
 import { timeFormater } from "@/utils/timeFormatter";
 import { useRouter } from "@/router/RouterProvider";
 import { useAuth } from "@/auth/AuthProvider";
+import buttonImg from "@/assets/more_button.svg";
+import { useEffect, useRef, useState } from "react";
+import { alert } from "@/components/common/CustomAlert";
 interface Props {
   feedItem: Tables<"get_feeds_with_user_and_likes"> & { preview_url?: string };
   onReplyClicked: () => void;
@@ -13,6 +16,10 @@ interface Props {
   isUserLike: boolean;
   onToggleLike: (feedId: string) => void;
   handleDelete: (feedId: string) => void;
+  scrollForDropdown: (
+    open: boolean,
+    dropdownRef: React.RefObject<HTMLUListElement | null>
+  ) => void;
 }
 
 function ChannelFeedMessage({
@@ -31,9 +38,30 @@ function ChannelFeedMessage({
   isUserLike,
   onToggleLike,
   handleDelete,
+  scrollForDropdown,
 }: Props) {
   const { user } = useAuth();
   const { setHistoryRoute } = useRouter();
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    document.addEventListener("mousedown", handleClose);
+    return () => {
+      document.removeEventListener("mousedown", handleClose);
+    };
+  }, []);
+
+  useEffect(() => {
+    scrollForDropdown(open, dropdownRef);
+  }, [open]);
+
+  const handleClose = (e: MouseEvent) => {
+    if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+      setOpen(false);
+    }
+  };
 
   const handleClick = (userId: string | null) => {
     if (!userId) return;
@@ -48,7 +76,9 @@ function ChannelFeedMessage({
   };
 
   const handleDeleteFeed = () => {
-    handleDelete(feed_id);
+    setOpen(false);
+    if (author_id !== user?.id) alert("피드 작성자만 삭제할 수 있습니다");
+    else handleDelete(feed_id);
   };
   const kst = timeFormater(created_at!);
   const createdTime = kst!.slice(0, 10) + " " + kst!.slice(11, 16);
@@ -69,10 +99,13 @@ function ChannelFeedMessage({
       </div>
       <div className={S.messageFeed}>
         <p>
-          <span onClick={() => handleClick(author_id)} style={{ cursor: "pointer" }}>
+          <span
+            onClick={() => handleClick(author_id)}
+            style={{ cursor: "pointer" }}
+          >
             {author_nickname}
           </span>
-           <small style={{ marginLeft: "4px" }}>{createdTime}</small>
+          <small style={{ marginLeft: "4px" }}>{createdTime}</small>
         </p>
         {image_url ? (
           <div className={S.imgContainer}>
@@ -99,15 +132,31 @@ function ChannelFeedMessage({
         <button type="button" onClick={handleReplyClicked}>
           댓글
         </button>
-        {author_id === user?.id ? (
-          <button
-            type="button"
-            className={S.deleteButton}
-            onClick={handleDeleteFeed}
-          >
-            삭제
+        <div ref={wrapperRef} className={S.dropdownWrapper}>
+          <button type="button" onClick={() => setOpen(!open)}>
+            <img height={"28px"} src={buttonImg} alt="더보기 버튼" />
           </button>
-        ) : null}
+          {open && (
+            <ul className={S.dropdownList} ref={dropdownRef}>
+              <li>
+                <button
+                  type="button"
+                  className={
+                    author_id === user?.id
+                      ? `${S.deleteButton}`
+                      : `${S.deleteButton} ${S.disabled}`
+                  }
+                  onClick={handleDeleteFeed}
+                >
+                  삭제
+                </button>
+              </li>
+              <li>
+                <button type="button">공유</button>
+              </li>
+            </ul>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Channel/components/DetailFeeds.tsx
+++ b/src/pages/Channel/components/DetailFeeds.tsx
@@ -3,7 +3,6 @@ import S from "./DetailContents.module.css";
 import heartEmpty from "@/assets/heart_empty_white.svg";
 import heartFilled from "@/assets/heart_filled_white.svg";
 import { useRouter } from "@/router/RouterProvider";
-import { useAuth } from "@/auth/AuthProvider";
 
 interface Props {
   feedItem: Tables<"get_feeds_with_user_and_likes"> & { preview_url?: string };
@@ -11,7 +10,6 @@ interface Props {
   onToggleLike: (feedId: string) => void;
   isUserLike: boolean;
   scrollToSelectedFeed: () => void;
-  handleDelete: (feedId: string) => void;
 }
 
 function DetailFeeds({
@@ -20,10 +18,8 @@ function DetailFeeds({
   onToggleLike,
   isUserLike,
   scrollToSelectedFeed,
-  handleDelete,
 }: Props) {
   const { setHistoryRoute } = useRouter();
-  const { user } = useAuth();
 
   const handleClick = (userId: string | null) => {
     if (!userId) return;
@@ -33,9 +29,6 @@ function DetailFeeds({
 
   const handleLikeToggle = () => {
     onToggleLike(feed_id!);
-  };
-  const handleDeleteFeed = () => {
-    handleDelete(feed_id!);
   };
 
   return (
@@ -61,15 +54,6 @@ function DetailFeeds({
             <button type="button" onClick={scrollToSelectedFeed}>
               현재 게시물로 돌아가기
             </button>
-            {author_id === user?.id ? (
-              <button
-                type="button"
-                className={S.deleteButton}
-                onClick={handleDeleteFeed}
-              >
-                삭제
-              </button>
-            ) : null}
           </div>
         </div>
       </div>

--- a/src/pages/Channel/index.tsx
+++ b/src/pages/Channel/index.tsx
@@ -112,8 +112,8 @@ function Channel() {
   );
 
   useEffect(() => {
-    console.log("isAtBottom 상태:", isAtBottom)
-  }, [isAtBottom])
+    console.log("isAtBottom 상태:", isAtBottom);
+  }, [isAtBottom]);
 
   const renderFeedComponent = useCallback(
     (feed: FeedWithPreview) => {
@@ -125,6 +125,7 @@ function Channel() {
         onReplyClicked: () => setSelectedFeed(feed),
         onToggleLike: () => onToggleLike(feed.feed_id!),
         handleDelete: handleDelete,
+        scrollForDropdown: scrollForDropdown,
       };
 
       if (feed.message_type === "clip")
@@ -167,6 +168,32 @@ function Channel() {
           top: offset,
           behavior: "smooth",
         });
+      }
+    }
+  };
+
+  const scrollForDropdown = (
+    open: boolean,
+    dropdownRef: React.RefObject<HTMLUListElement | null>
+  ) => {
+    if (open && dropdownRef.current && feedContainerRef.current) {
+      const dropdownEl = dropdownRef.current;
+      const containerEl = feedContainerRef.current;
+
+      const dropdownRect = dropdownEl.getBoundingClientRect();
+      const containerRect = containerEl.getBoundingClientRect();
+
+      const isDropdownVisible =
+        dropdownRect.bottom <= containerRect.bottom &&
+        dropdownRect.top >= containerRect.top;
+
+      if (!isDropdownVisible) {
+        const offset = dropdownRect.top - containerRect.top - 12;
+        if (containerEl.scrollTop > 0) {
+          containerEl.scrollBy({ top: offset, behavior: "smooth" });
+        } else if (dropdownRect.top < containerRect.top) {
+          dropdownEl.style.top = "40px"; // fallback 위치 조정
+        }
       }
     }
   };
@@ -471,7 +498,7 @@ function Channel() {
           })
         );
         setFeedData(updatedFeeds);
-        
+
         requestAnimationFrame(() => {
           scrollToBottom();
         });
@@ -609,7 +636,6 @@ function Channel() {
                           userLikes?.includes(selectedFeed.feed_id!) ?? false
                         }
                         scrollToSelectedFeed={scrollToSelectedFeed}
-                        handleDelete={handleDelete}
                       />
                       <FeedReplies
                         replies={repliesData}


### PR DESCRIPTION
## 작업 개요
채널 피드에서 더보기 버튼을 놀렀을 때 삭제버튼과 공유버튼이 나오도록 수정했습니다. 

## 작업 내용
- [x] 채널 피드 토글버튼 제작
- [x] 채널 피드 토글버튼 열리면 화면에 표시되지 않는 경우 스크롤 이동, 맨 위 피드의 경우 토글 밑으로 열리게 함
- [x] 댓글창에 있는 피드삭제버튼 삭제
- [ ] 피드공유기능

## 관련 이슈

## 테스트 결과 보고
