### PR TITLE
[Feat] RealTime Load 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta property="og:title" content="MusicMate" />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="https://whbwjepooojxjoufcift.supabase.co/storage/v1/object/public/feed-images//logo.jpg"/>
+    <meta property="og:description" content="음악 SNS 커뮤니티, MusicMate"/>
+    <meta property="og:url" content="https://music-mate-kappa.vercel.app/" />
+
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css"

--- a/src/pages/Channel/components/ChannelFeedMessage.tsx
+++ b/src/pages/Channel/components/ChannelFeedMessage.tsx
@@ -9,6 +9,7 @@ import { useAuth } from "@/auth/AuthProvider";
 import buttonImg from "@/assets/more_button.svg";
 import { useEffect, useRef, useState } from "react";
 import { alert } from "@/components/common/CustomAlert";
+import { copyFeedLinkToClipboard } from "@/utils/copyFeedLinkToClipboard";
 interface Props {
   feedItem: Tables<"get_feeds_with_user_and_likes"> & { preview_url?: string };
   onReplyClicked: () => void;
@@ -32,6 +33,7 @@ function ChannelFeedMessage({
     preview_url,
     like_count,
     author_id,
+    channel_id,
   },
   onReplyClicked,
   isActive,
@@ -82,6 +84,10 @@ function ChannelFeedMessage({
   };
   const kst = timeFormater(created_at!);
   const createdTime = kst!.slice(0, 10) + " " + kst!.slice(11, 16);
+
+  const handleCopyFeedLink = () => {
+    copyFeedLinkToClipboard(channel_id ?? "", feed_id);
+  };
 
   return (
     <div
@@ -152,7 +158,9 @@ function ChannelFeedMessage({
                 </button>
               </li>
               <li>
-                <button type="button">공유</button>
+                <button type="button" onClick={handleCopyFeedLink}>
+                  공유
+                </button>
               </li>
             </ul>
           )}

--- a/src/pages/Channel/index.tsx
+++ b/src/pages/Channel/index.tsx
@@ -5,7 +5,6 @@ import ChannelFeedMessage from "./components/ChannelFeedMessage";
 import {
   useCallback,
   useEffect,
-  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -71,7 +70,6 @@ function Channel() {
   const [hasMoreHeadFeeds, setHasMoreHeadFeeds] = useState(true);
   const [isTopFetching, setIsTopFetching] = useState<boolean>(false);
   const [isBottomFetching, setIsBottomFetching] = useState<boolean>(false);
-  const [isSubmit, setIsSubmit] = useState<boolean>(false);
   const [isAtBottom, setIsAtBottom] = useState(true);
 
   const feedRefs = useRef<Record<string, HTMLLIElement | null>>({});
@@ -308,12 +306,8 @@ function Channel() {
         ...(prev ?? []),
         newFeed,
       ]);
-
-      if (isAtBottom) {
-        setIsSubmit((prev) => !prev);
-      }
     },
-    [isAtBottom, userProfile?.nickname, userProfile?.profile_url]
+    [userProfile?.nickname, userProfile?.profile_url]
   );
 
   // 첫 요소에서 20개를 더 로드
@@ -351,7 +345,9 @@ function Channel() {
     });
 
     requestAnimationFrame(() => {
-      const newFirstEl = feedRefs.current[firstFeedId];
+      // 선택된 피드가 있다면 해당 피드로 스크롤
+      const selectedFeed = paramsFeedId ? paramsFeedId : firstFeedId
+      const newFirstEl = feedRefs.current[selectedFeed];
       const newOffset = newFirstEl?.getBoundingClientRect().top ?? 0;
 
       if (container) {

--- a/src/pages/Channel/index.tsx
+++ b/src/pages/Channel/index.tsx
@@ -346,8 +346,7 @@ function Channel() {
 
     requestAnimationFrame(() => {
       // 선택된 피드가 있다면 해당 피드로 스크롤
-      const selectedFeed = paramsFeedId ? paramsFeedId : firstFeedId
-      const newFirstEl = feedRefs.current[selectedFeed];
+      const newFirstEl = feedRefs.current[firstFeedId];
       const newOffset = newFirstEl?.getBoundingClientRect().top ?? 0;
 
       if (container) {
@@ -677,7 +676,10 @@ function Channel() {
                       <button
                         type="button"
                         className={S.closeButton}
-                        onClick={() => setSelectedFeed(null)}
+                        onClick={() => {
+                          // 뒤로가기 시에도 피드 상세를 남기지 않음.
+                          window.history.replaceState({}, "", `/Channel/${id}`)
+                          setSelectedFeed(null)}}
                       >
                         <img src={close} alt="" />
                       </button>

--- a/src/utils/copyFeedLinkToClipboard.ts
+++ b/src/utils/copyFeedLinkToClipboard.ts
@@ -1,0 +1,12 @@
+export const copyFeedLinkToClipboard = (channelId: string, feedId: string) => {
+  const baseUrl = window.location.href.replace(window.location.pathname, "");
+  const fullUrl = `${baseUrl}/Channel/${channelId}/feed/${feedId}`;
+
+  navigator.clipboard.writeText(fullUrl)
+    .then(() => {
+      console.log("링크가 클립보드에 복사되었습니다:", fullUrl);
+    })
+    .catch((err) => {
+      console.error("클립보드 복사 실패:", err);
+    });
+};


### PR DESCRIPTION
## 작업 개요
<!-- 어떤 작업을 했는지 간단히 작성해주세요 -->
RealTime Load Listener 구현, 필요 없는 ScrollEvent 관리 State, Effect 제거, 피드 상세보기를 닫을 때 paramsFeedId도 제거하도록 설정

## 작업 내용
- [x] RealTime Load Listener 구현
- [x] 필요 없는 ScrollEvent 관리 State, Effect 제거
- [x] 피드 상세보기를 닫을 때 paramsFeedId도 제거하도록 설정 ( 새로고침, 뒤로가기 시 이전 정보 가져오기 방지 )
- [x] 피드 공유 버튼을 클릭해 클립보드에 링크를 복사하는 copyFeedLinkToClipboard 유틸 함수
- [x] 피드를 공유했을 때 볼 수 있는 metadata 설정 
- [ ] 선택된 피드가 있다면 renderHeadFeeds에서 스크롤 방지(취소)

## 관련 이슈
Closes #147, #149

## 테스트 결과 보고
<!-- 테스트 결과나 내용 기입 -->
다른 서버에서 보내면 바로 리로드됩니다.