### PR TITLE
[Design] 피드 이미지 패딩 삭제, 인기게시물 truncate 적용

### DIFF
--- a/src/pages/Channel/components/ChannelFeed.module.css
+++ b/src/pages/Channel/components/ChannelFeed.module.css
@@ -198,7 +198,7 @@ h3 small {
   display: flex;
   justify-content: start;
   align-items: center;
-  padding: 1rem;
+  padding: 0;
 }
 
 .feedImage {

--- a/src/pages/Main/components/FeedList.tsx
+++ b/src/pages/Main/components/FeedList.tsx
@@ -7,38 +7,41 @@ import { useEffect, useState } from "react";
 import { getPopularFeeds } from "@/api";
 import ChannelLink from "@/components/common/Link/ChannelLink";
 import heartFilledWhite from "@/assets/heart_filled_white.svg";
-
+import { truncateText } from "@/utils/truncateText";
 
 function FeedList() {
-  const [feeds,setFeeds] = useState<Tables<"get_feeds_with_user_and_likes">[]>([]);
-  
-  useEffect(()=>{
-    const fetchFeeds = async()=>{
+  const [feeds, setFeeds] = useState<Tables<"get_feeds_with_user_and_likes">[]>(
+    []
+  );
+
+  useEffect(() => {
+    const fetchFeeds = async () => {
       const data = await getPopularFeeds();
-      if(data) setFeeds(data);
+      if (data) setFeeds(data);
     };
     fetchFeeds();
-  },[]);
+  }, []);
 
   return (
     <>
       <h2 className={S.title}>인기 게시글</h2>
       <div className={S.feedGrid}>
-        {feeds?.slice(0,6).map((feed)=>(
-          <div
-          key={feed.feed_id}
-          className={S.feedItem}
-          >
+        {feeds?.slice(0, 6).map((feed) => (
+          <div key={feed.feed_id} className={S.feedItem}>
             <ChannelLink channelId={feed.channel_id!} feedId={feed.feed_id!}>
               <div className={S.postContent}>
-                <p className={S.preview}>{feed.content?.slice(0,40)}</p>
+                <p className={S.preview}>
+                  {feed.content ? truncateText(feed.content, 40) : null}
+                </p>
               </div>
             </ChannelLink>
 
             <div className={S.likeContainer}>
-              <img 
+              <img
                 style={{ width: "16px", height: "16px" }}
-                src={heartFilledWhite} alt="좋아요" />
+                src={heartFilledWhite}
+                alt="좋아요"
+              />
               <span className={S.likeCount}>{feed.like_count ?? 0}</span>
             </div>
           </div>

--- a/src/utils/truncateText.ts
+++ b/src/utils/truncateText.ts
@@ -1,4 +1,4 @@
 export function truncateText(text: string, limit: number = 100): string {
-  if (text.length > limit) return text.slice(0, limit) + "...";
+  if (text.length > limit) return text.slice(0, limit) + " . . .";
   return text;
 }


### PR DESCRIPTION
## 작업 개요
이미지가 포함된 피드의 이미지 패딩을 삭제했습니다
인기게시물 contents 에 truncate를 적용했습니다

## 작업 내용
- [x] 피드 이미지 패딩 삭제
- [x] 인기게시물 truncate 적용

## 관련 이슈

## 테스트 결과 보고
